### PR TITLE
Refactor the image generation agent to be resilient to LLM parameter …

### DIFF
--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -12,17 +12,18 @@ tools = [generate_image]
 llm = ChatOllama(model=settings.OLLAMA_MODEL, temperature=0.7, format="json")
 
 # --- 3. Create the Prompt ---
-# This is the final key change. We are being extremely explicit in the prompt,
-# telling the LLM the exact name and argument ('prompt') of the tool it must use.
-# This eliminates any remaining ambiguity and prevents it from hallucinating
-# a complex, incorrect tool call.
+# With the Pydantic model handling validation, we can simplify the prompt.
+# We no longer need to aggressively restrict the LLM. We can give it a more
+# natural instruction, and LangChain will automatically provide the tool's
+# schema (from the Pydantic model) to the LLM.
 prompt = ChatPromptTemplate.from_messages(
     [
         (
             "system",
-            "You are a specialized assistant whose only purpose is to call the 'generate_image' tool. "
-            "The 'generate_image' tool takes a single string argument named 'prompt'. "
-            "Your sole output must be a JSON object that calls the 'generate_image' tool with this single 'prompt' argument.",
+            "You are an expert at generating images. "
+            "Use the user's request to call the `generate_image` tool. "
+            "If the user provides details like style, steps, or negative prompts, "
+            "include them in the tool call.",
         ),
         ("user", "{input}"),
         ("placeholder", "{agent_scratchpad}"),

--- a/app/agent/tools.py
+++ b/app/agent/tools.py
@@ -4,44 +4,74 @@ import requests
 from langchain.tools import tool
 from pathlib import Path
 import time
+from typing import Optional
+
+from pydantic import BaseModel, Field
 
 from app.core.settings import settings
 
 
-# --- Tool Definition ---
-# By simplifying the tool definition to a standard function with a type-hinted
-# string argument, we create a much clearer "contract" for the LLM.
-# It no longer needs to guess the structure of a complex input object.
-@tool
-def generate_image(prompt: str) -> str:
-    """
-    Generates an image from a text prompt using the AUTOMATIC1111 API
-    and returns a JSON string containing the image data and the final prompt.
-    """
-    print("--- 🖼️ Calling Image Generation Tool ---")
-    print(f"Initial Prompt: {prompt}")
+# --- Pydantic Model for Tool Input ---
+# This model defines the "contract" for the image generation tool.
+# By using a Pydantic model, we allow the LLM to provide a richer set of
+# parameters, but we validate them strictly. The LLM can be "creative,"
+# and we can handle it gracefully.
+class ImageGeneratorInput(BaseModel):
+    prompt: str = Field(description="A detailed, descriptive prompt for the image.")
+    negative_prompt: Optional[str] = Field(
+        default="ugly, tiling, poorly drawn hands, poorly drawn feet, poorly drawn face, out of frame, extra limbs, disfigured, deformed, body out of frame, bad anatomy, watermark, signature, cut off, low contrast, underexposed, overexposed, bad art, beginner, amateur, distorted face",
+        description="A detailed prompt of things to exclude from the image.",
+    )
+    steps: Optional[int] = Field(
+        default=None, description="Number of sampling steps (e.g., 20-40)."
+    )
+    cfg_scale: Optional[float] = Field(
+        default=7.0, description="Classifier-Free Guidance scale (e.g., 7.0)."
+    )
+    width: Optional[int] = Field(default=None, description="Image width in pixels.")
+    height: Optional[int] = Field(default=None, description="Image height in pixels.")
+    sampler_name: Optional[str] = Field(
+        default=None, description="The sampling method (e.g., 'Euler', 'DPM++ 2M Karras')."
+    )
 
-    # --- Set Image Quality based on FAST_MODE ---
+
+# --- Tool Definition ---
+# We now pass the Pydantic model directly to the @tool decorator.
+# LangChain will automatically handle the conversion from the LLM's JSON output
+# into a populated instance of the ImageGeneratorInput class.
+@tool(args_schema=ImageGeneratorInput)
+def generate_image(tool_input: ImageGeneratorInput) -> str:
+    """
+    Generates an image from a text prompt and other parameters using the AUTOMATIC1111 API.
+    Returns a JSON string containing the image data and final prompt.
+    """
+    print("--- 🖼️ Calling Image Generation Tool with Pydantic Model ---")
+    print(f"Tool Input: {tool_input.model_dump_json(indent=2)}")
+
+    # --- Set Image Quality Defaults based on FAST_MODE ---
+    # If the user (or LLM) provides specific values, they will override these.
     if settings.FAST_MODE:
-        steps = 10
-        sampler_name = "Euler"
-        width = 512
-        height = 512
+        default_steps = 10
+        default_sampler = "Euler"
+        default_width = 512
+        default_height = 512
     else:
-        steps = 25
-        sampler_name = "DPM++ 2M Karras"
-        width = 1024
-        height = 1024
+        default_steps = 25
+        default_sampler = "DPM++ 2M Karras"
+        default_width = 1024
+        default_height = 1024
 
     # --- API Payload ---
+    # We construct the payload by coalescing the validated tool input with our defaults.
+    # This is the core of the robust solution: we trust our Pydantic model, not the raw LLM output.
     payload = {
-        "prompt": prompt,
-        "negative_prompt": "ugly, tiling, poorly drawn hands, poorly drawn feet, poorly drawn face, out of frame, extra limbs, disfigured, deformed, body out of frame, bad anatomy, watermark, signature, cut off, low contrast, underexposed, overexposed, bad art, beginner, amateur, distorted face",
-        "steps": steps,
-        "cfg_scale": 7,
-        "width": width,
-        "height": height,
-        "sampler_name": sampler_name,
+        "prompt": tool_input.prompt,
+        "negative_prompt": tool_input.negative_prompt,
+        "steps": tool_input.steps or default_steps,
+        "cfg_scale": tool_input.cfg_scale,
+        "width": tool_input.width or default_width,
+        "height": tool_input.height or default_height,
+        "sampler_name": tool_input.sampler_name or default_sampler,
     }
 
     # --- Make the API Request ---
@@ -72,10 +102,10 @@ def generate_image(prompt: str) -> str:
         print(f"Image saved to: {file_path}")
 
         # --- Prepare the JSON Output ---
-        # We now return the definitive JSON string that our API route expects.
+        # The final prompt used is now part of the payload.
         result = {
             "image_base64": image_data,
-            "final_prompt": prompt,
+            "final_prompt": payload["prompt"],
             "saved_path": str(file_path),
         }
         return json.dumps(result)


### PR DESCRIPTION
…hallucination.

The previous implementation attempted to force the LLM to adhere to a rigid, single-argument tool signature using strict prompts. This approach was brittle and failed when the LLM tried to be 'helpful' by providing extra parameters.

This commit refactors the architecture to a more robust pattern:

1.  A Pydantic model (`ImageGeneratorInput`) is introduced to define a clear schema for the `generate_image` tool's arguments. This model acts as a validation layer.

2.  The `generate_image` tool is updated to use this Pydantic model as its `args_schema`. This allows LangChain to automatically parse and validate the LLM's JSON output. Any extraneous or "hallucinated" parameters are safely ignored.

3.  The tool's internal logic is updated to build its API payload from the validated Pydantic object, coalescing with default values for quality and stability.

4.  The agent's system prompt is simplified to be more of a general guide, working with the LLM's natural tendencies rather than against them.

This change moves the responsibility of contract enforcement from the probabilistic LLM to the deterministic application code, resulting in a more stable and predictable system.